### PR TITLE
日記登録APIの再実装

### DIFF
--- a/src/application/usecase/bodyRecord/bodyRecord.usecases.ts
+++ b/src/application/usecase/bodyRecord/bodyRecord.usecases.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
-import {BODYRECORD_REPOSITORY, BodyRecordRepository} from '@/infrastructure/interfaces/bodyRecord.type';
-import { bodyRecord, createBodyRecord, updateBodyRecord } from '@/domain/bodyRecord.type';
+import {
+  BODYRECORD_REPOSITORY,
+  BodyRecordRepository,
+} from '@/infrastructure/interfaces/bodyRecord.type';
+import {
+  bodyRecord,
+  createBodyRecord,
+  updateBodyRecord,
+} from '@/domain/bodyRecord.type';
 
 @Injectable()
 export class BodyRecordUseCase {

--- a/src/application/usecase/diary/diary.usecase.ts
+++ b/src/application/usecase/diary/diary.usecase.ts
@@ -3,7 +3,7 @@ import {
   DIARY_REPOSITORY,
   DiaryRepository,
 } from '@/infrastructure/interfaces/diary.type';
-import { Diary, UpdateDiary } from '@/domain/diary.type';
+import { Diary, UpdateDiary, CreateDiary } from '@/domain/diary.type';
 
 @Injectable()
 export class DiaryUseCase {
@@ -21,5 +21,8 @@ export class DiaryUseCase {
   }
   async findByUserId(getDiary: Diary): Promise<Diary | null> {
     return this.diaryRepository.findByUserId(getDiary);
+  }
+  async createDiary(createDiary: CreateDiary): Promise<boolean> {
+    return this.diaryRepository.createDiary(createDiary);
   }
 }

--- a/src/domain/diary.type.ts
+++ b/src/domain/diary.type.ts
@@ -7,4 +7,10 @@ export type UpdateDiary = {
 export type Diary = {
   userId: string;
   date: Date;
-}
+};
+
+export type CreateDiary = {
+  userId: string;
+  date: Date;
+  contents: string;
+};

--- a/src/domain/diary.type.ts
+++ b/src/domain/diary.type.ts
@@ -1,5 +1,5 @@
 export type UpdateDiary = {
-  userId?: string;
+  userId: string;
   date: Date;
   contents: string;
 };

--- a/src/infrastructure/interfaces/bodyRecord.type.ts
+++ b/src/infrastructure/interfaces/bodyRecord.type.ts
@@ -1,4 +1,8 @@
-import { bodyRecord, createBodyRecord, updateBodyRecord } from '@/domain/bodyRecord.type';
+import {
+  bodyRecord,
+  createBodyRecord,
+  updateBodyRecord,
+} from '@/domain/bodyRecord.type';
 
 export const BODYRECORD_REPOSITORY = Symbol.for('BODYRECORD_REPOSITORY');
 

--- a/src/infrastructure/interfaces/diary.type.ts
+++ b/src/infrastructure/interfaces/diary.type.ts
@@ -1,4 +1,4 @@
-import { Diary, UpdateDiary } from '@/domain/diary.type';
+import { Diary, UpdateDiary, CreateDiary } from '@/domain/diary.type';
 
 export const DIARY_REPOSITORY = Symbol.for('DIARY_REPOSITORY');
 
@@ -9,4 +9,5 @@ export interface DiaryRepository {
    */
   updateByUserId(updateDiary: UpdateDiary);
   findByUserId(getDiary: Diary);
+  createDiary(createDiary: CreateDiary);
 }

--- a/src/infrastructure/prisma_repository/bodyRecord/bodyRecord.repository.ts
+++ b/src/infrastructure/prisma_repository/bodyRecord/bodyRecord.repository.ts
@@ -27,11 +27,11 @@ export class BodyRecordRepositoryImpl implements BodyRecordRepository {
   }
   async createBodyRecord(createBodyRecord: createBodyRecord) {
     return this.prisma.bodyRecord.create({
-      data: { 
+      data: {
         userId: createBodyRecord.userId,
         date: createBodyRecord.date,
         value: createBodyRecord.value,
-        },
-      });  
-    }
+      },
+    });
+  }
 }

--- a/src/infrastructure/prisma_repository/diary/diary.repository.ts
+++ b/src/infrastructure/prisma_repository/diary/diary.repository.ts
@@ -1,7 +1,7 @@
 import { DiaryRepository } from '@/infrastructure/interfaces/diary.type';
 import { PrismaService } from '../prisma.service';
 import { Injectable } from '@nestjs/common';
-import { Diary, UpdateDiary } from '@/domain/diary.type';
+import { Diary, UpdateDiary, CreateDiary } from '@/domain/diary.type';
 
 @Injectable()
 export class DiaryRepositoryImpl implements DiaryRepository {
@@ -28,7 +28,15 @@ export class DiaryRepositoryImpl implements DiaryRepository {
         },
       },
       select: { contents: true },
-    }
-    );
+    });
+  }
+  async createDiary(createDiary: CreateDiary) {
+    return this.prisma.diary.create({
+      data: {
+        userId: createDiary.userId,
+        date: createDiary.date,
+        contents: createDiary.contents,
+      },
+    });
   }
 }

--- a/src/presentation/controller/bodyRecord/bodyRecord.contoroller.ts
+++ b/src/presentation/controller/bodyRecord/bodyRecord.contoroller.ts
@@ -51,6 +51,5 @@ export class BodyRecordController {
       createBodyRecord,
     );
     return result;
-  
   }
 }

--- a/src/presentation/controller/bodyRecord/request.interface.ts
+++ b/src/presentation/controller/bodyRecord/request.interface.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsNumber} from 'class-validator';
+import { IsNotEmpty, IsNumber } from 'class-validator';
 
 export class GetRequest {
   @IsNotEmpty({ message: 'ユーザIDを入力してください' })

--- a/src/presentation/controller/diary/diary.controller.ts
+++ b/src/presentation/controller/diary/diary.controller.ts
@@ -44,17 +44,16 @@ export class DiaryController {
 
   @Post('users/:userId/dates/:date/diary/create')
   async post(
-    @Param() { userId }: PostRequest,
-    @Param() { date }: PostRequest,
-    @Body() createDiaryRequest: PostRequest,
+    @Param('userId') userId: string,
+    @Body('date') date: PostRequest['date'],
+    @Body('contents') contents: PostRequest['contents'],
   ): Promise<boolean> {
-    console.log(createDiaryRequest);
     const createDiary = {
       userId: userId,
       date: new Date(date),
-      contents: createDiaryRequest.contents,
+      contents: contents,
     };
     const result = await this.diaryUseCase.createDiary(createDiary);
     return result;
-  };
+  }
 }

--- a/src/presentation/controller/diary/diary.controller.ts
+++ b/src/presentation/controller/diary/diary.controller.ts
@@ -4,8 +4,9 @@ import {
   Put,
   Body,
   Get,
+  Post
 } from '@nestjs/common';
-import { DiaryGetRequest, PutRequest } from './request.interface';
+import { DiaryGetRequest, PutRequest, PostRequest } from './request.interface';
 import { DiaryGetResponse } from './response.interface';
 import { DiaryUseCase } from '@/application/usecase/diary/diary.usecase';
 
@@ -40,4 +41,20 @@ export class DiaryController {
     const result = await this.diaryUseCase.findByUserId(getDiary);
     return result;
   }
+
+  @Post('users/:userId/dates/:date/diary/create')
+  async post(
+    @Param() { userId }: PostRequest,
+    @Param() { date }: PostRequest,
+    @Body() createDiaryRequest: PostRequest,
+  ): Promise<boolean> {
+    console.log(createDiaryRequest);
+    const createDiary = {
+      userId: userId,
+      date: new Date(date),
+      contents: createDiaryRequest.contents,
+    };
+    const result = await this.diaryUseCase.createDiary(createDiary);
+    return result;
+  };
 }

--- a/src/presentation/controller/diary/request.interface.ts
+++ b/src/presentation/controller/diary/request.interface.ts
@@ -20,3 +20,16 @@ export class DiaryGetRequest {
   @IsNotEmpty({ message: '日付を入力してください' })
   date: string;
 }
+
+export class PostRequest {
+  @IsNotEmpty({ message: 'ユーザーIDを入力してください' })
+  userId: string;
+
+  @IsNotEmpty({ message: '日付を入力してください' })
+  date: string;
+
+  @IsNotEmpty({ message: '内容を入力してください' })
+  @IsString({ message: '内容は文字列で入力してください' })
+  @MaxLength(500, { message: '内容は500文字以内で入力してください' })
+  contents: string;
+}

--- a/src/presentation/controller/diary/request.interface.ts
+++ b/src/presentation/controller/diary/request.interface.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, MaxLength, Matches } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength, Matches,IsDate } from 'class-validator';
 
 export class PutRequest {
   @IsNotEmpty({ message: '内容を入力してください' })
@@ -22,14 +22,19 @@ export class DiaryGetRequest {
 }
 
 export class PostRequest {
-  @IsNotEmpty({ message: 'ユーザーIDを入力してください' })
-  userId: string;
-
   @IsNotEmpty({ message: '日付を入力してください' })
+  @IsDate({ message : '日付を入力してください' })
   date: string;
 
   @IsNotEmpty({ message: '内容を入力してください' })
   @IsString({ message: '内容は文字列で入力してください' })
   @MaxLength(500, { message: '内容は500文字以内で入力してください' })
+  @Matches(
+    /^[a-zA-Z0-9\s!@#$%^&*()_+{}\[\]:;<>,.?~\\/-\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]+$/,
+    {
+      message:
+        '内容には特殊文字を除く半角英数字、一部の記号、および日本語が使用できます',
+    },
+  )
   contents: string;
 }


### PR DESCRIPTION
## やったこと

* 日記登録APIの再実装

## やらないこと

* 日記登録API以外の部分の修正、実装

## 何ができるか

* ユーザーが日記（diary）の新規登録

## 動作確認

* Postmanでのhttp\://localhost:3001/users/:ユーザーId/dates/ユーザーの登録日付/diary/createへPostリクエストの押下

**Request**

```
{
    "date": "1970-01-17T00:00:00.000",
    "contents" : "test2"
}
```

**Response**

```
{
    "userId": "jondoe",
    "date": "1970-01-16T00:00:00.000Z",
    "contents": "test2",
    "createdAt": "2023-09-21T01:34:50.186Z",
    "updatedAt": "2023-09-21T01:34:50.186Z"
}
```